### PR TITLE
DynamicHTML: Fix leaking components when content changes

### DIFF
--- a/src/dynamic-html/dynamic-html.component.ts
+++ b/src/dynamic-html/dynamic-html.component.ts
@@ -43,7 +43,7 @@ import { DynamicHTMLRenderer, DynamicHTMLRef } from './renderer';
 export class DynamicHTMLComponent implements DoCheck, OnChanges, OnDestroy {
   @Input() content: string;
 
-  private ref: DynamicHTMLRef;
+  private ref: DynamicHTMLRef = null;
 
   constructor(
     private renderer: DynamicHTMLRenderer,
@@ -51,6 +51,10 @@ export class DynamicHTMLComponent implements DoCheck, OnChanges, OnDestroy {
   ) { }
 
   ngOnChanges(_: SimpleChanges) {
+    if (this.ref) {
+      this.ref.destroy();
+      this.ref = null;
+    }
     if (this.content && this.elementRef) {
       this.ref = this.renderer.renderInnerHTML(this.elementRef, this.content);
     }
@@ -65,6 +69,7 @@ export class DynamicHTMLComponent implements DoCheck, OnChanges, OnDestroy {
   ngOnDestroy() {
     if (this.ref) {
       this.ref.destroy();
+      this.ref = null;
     }
   }
 }


### PR DESCRIPTION
When ngOnChanges is called, because for instance the content input of
the dynamic-html element has changed, a new rendering is created. It
results on a new DynamicHTMLRef instance replacing the old one, but the
old one was never disposed of, which resulted in the leak of the
previous components, and ngOnDestroy() was never called on them.

This commit fixes that by explicitely calling DynamicHTMLRef.destroy()
before rendering the new content.