### PR TITLE
fixed issue #22

### DIFF
--- a/src/dynamic-component/dynamic-component.directive.spec.ts
+++ b/src/dynamic-component/dynamic-component.directive.spec.ts
@@ -41,6 +41,17 @@ class MultipleCmp {
     ];
 }
 
+@Component({
+    template: `<div *dynamicComponent="template; context: this;"></div>`
+})
+class ButtonComponent {
+    template = `<div><button (click)="onButtonClicked($event)">Click me</button></div>`;
+
+    onButtonClicked() {
+        console.log('button clicked');
+    }
+}
+
 describe('dynamicComponent', () => {
 
     beforeEach(() => {
@@ -52,7 +63,7 @@ describe('dynamicComponent', () => {
                     declarations: [] // for issue #27
                 })
             ],
-            declarations: [MultipleCmp, TestCmp],
+            declarations: [MultipleCmp, TestCmp, ButtonComponent],
         });
     });
 
@@ -115,6 +126,22 @@ describe('dynamicComponent', () => {
             fixture.ngZone.onStable.subscribe(() => {
                 console.log(fixture.nativeElement.innerHTML);
                 expect(fixture.nativeElement.textContent).toBe(`${now}`);
+            });
+        });
+    }));
+
+    it('button clicked', async(() => {
+        TestBed.compileComponents().then(() => {
+            const fixture = TestBed.createComponent(ButtonComponent);
+            const component = fixture.componentInstance;
+            spyOn(component, 'onButtonClicked');
+
+            fixture.detectChanges();
+            fixture.ngZone.onStable.subscribe(() => {
+                let button = fixture.debugElement.nativeElement.querySelector('button');
+                button.click();
+                console.log(fixture.nativeElement.innerHTML);
+                expect(component.onButtonClicked).toHaveBeenCalled();
             });
         });
     }));

--- a/src/dynamic-component/dynamic-component.directive.ts
+++ b/src/dynamic-component/dynamic-component.directive.ts
@@ -110,7 +110,24 @@ export class DynamicComponentDirective implements OnDestroy {
         if (cmpFactory) {
           this.vcRef.clear();
           this.component = this.vcRef.createComponent(cmpFactory, 0, injector);
-          Object.assign(this.component.instance, this.context);
+
+          if (this.context !== null && this.context !== undefined) {
+            Object.assign(this.component.instance, this.context);
+
+            const proto = Object.getPrototypeOf(this.context);
+            // don't copy default functions from plain objects
+            if (proto !== undefined && proto !== null && proto !== Object.prototype) {
+
+              const func = Object
+                  .getOwnPropertyNames(proto)
+                  .filter((entry) => typeof this.context[entry] === 'function' && entry !== 'constructor');
+
+              let funcMap: any = {};
+              func.forEach((funcName) => funcMap[funcName] = this.context[funcName].bind(this.context));
+              Object.assign(this.component.instance, funcMap);
+            }
+          }
+
           this.component.changeDetectorRef.detectChanges();
         }
       });


### PR DESCRIPTION
This pull request fixes issue #22. I also added a test case for further development.

The function `Object.assign` does not work for class functions, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
My workaround creates a key-value map of functions with references to the origin class and assign them to the dynamic component instance. 